### PR TITLE
bug: format macro not working

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,9 @@
 #[macro_use]
 extern crate pbc_contract_codegen;
 
+use pbc_contract_common::address::Address;
 use pbc_contract_common::context::{ContractContext};
+use pbc_contract_common::info as log;
 
 
 /// This is the state of the contract which is persisted on chain.
@@ -44,6 +46,7 @@ fn greet(
     state: ContractState,
     name: String,
 ) -> ContractState {
+    log(format!("Name is {}", name));
     assert!(!name.is_empty(), "name must not be empty");
 
     let mut new_state = state;


### PR DESCRIPTION
It seems PBC wasm interpreter is throwing an error when using `format!` macro in the contract.

![image](https://user-images.githubusercontent.com/14256602/211177340-06110c53-3f41-4eb0-9589-b45e9be911ae.png)

In this example, I have used the macro inside an action.

The stack trace is as follows:

![image](https://user-images.githubusercontent.com/14256602/211177356-cfe04f36-0d24-4bb2-bc8a-99e82cb60502.png)
